### PR TITLE
Wiremock for VipCore

### DIFF
--- a/src/corepo_solr_testrunner/testrunner.py
+++ b/src/corepo_solr_testrunner/testrunner.py
@@ -72,6 +72,7 @@ class TestRunner( AbstractTestRunner ):
             solr_doc_store_monitor = container_suite.get("solr-doc-store-monitor", build_folder)
             opensearch = container_suite.get("opensearch", build_folder)
             wiremock = container_suite.get("wiremock", build_folder)
+            vipcore = container_suite.get("vipcore", build_folder)
             corepo_db = container_suite.get("corepo-db", build_folder)
 
             gdih = SolrDockerGDIH(corepo_db)


### PR DESCRIPTION
Bruger en WireMock med en optagelse af Vipcore i Acceptance Test af indeksering (det samme kan laves for Hive og Addi acceptance test)

https://is.dbc.dk/job/os-wiremock-rules/ har tilføjet et "wiremock-vipcore.zip" artifact med optagelse af Vipcore:
https://phabricator.k8s.dbc.dk/rSVN128073